### PR TITLE
Reduce python version constraint

### DIFF
--- a/dialog_tag/DialogTag.py
+++ b/dialog_tag/DialogTag.py
@@ -12,13 +12,13 @@ from . import __version__
 
 
 class DialogTag:
-    def __init__(self, model_name):
+    def __init__(self, model_name, model_path=None):
 
         self.__model_name = model_name
 
         self.__lib_path = f"{str(Path.home())}"+ model_location["MODEL"]
-        self.__model_path = os.path.join(self.__lib_path, self.__model_name)
-        self.__label_mapping_path = os.path.join(self.__lib_path, self.__model_name) + model_location["label_mapping"]
+        self.__model_path = model_path or os.path.join(self.__lib_path, self.__model_name)
+        self.__label_mapping_path = self.__model_path + model_location["label_mapping"]
 
         # print(self.__lib_path, self.__model_path, self.__label_mapping_path)
         path_exists = os.path.exists(self.__model_path)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.6',
     keywords="Tensorflow BERT NLP deep learning Transformer Networks "
 )


### PR DESCRIPTION
Since the library doesn't use any `python3.7` specific features, add support for `python3.6` as well?